### PR TITLE
Support toggling native auth programmatically

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -174,19 +174,20 @@ class Plugin extends PluginBase
         });
 
         \Backend\Controllers\Auth::extend(function ($controller) {
+            if (Config::get('winter.sso::prevent_native_auth', false)) {
+                return;
+            }
 
-			if (!Config::get('winter.sso::prevent_native_auth', false)) return;
-
-		    // Disable the login form visually
-		    $controller->addViewPath(plugins_path('winter/sso/controllers/auth/prevent_native'));
-
-		    // Disable server processing of any auth AJAX handlers to protect against manually crafted requests
-		    $controller->bindEvent('ajax.beforeRunHandler', function ($handler) {
-			    if ($handler === 'onSubmit') {
-				    throw new ApplicationException("Native authentication is disabled.");
-			    }
-		    });
-	    });
+            // Disable the login form visually
+            $controller->addViewPath(plugins_path('winter/sso/controllers/auth/prevent_native'));
+        
+            // Disable server processing of any auth AJAX handlers to protect against manually crafted requests
+            $controller->bindEvent('ajax.beforeRunHandler', function ($handler) {
+                if ($handler === 'onSubmit') {
+                throw new ApplicationException("Native authentication is disabled.");
+                }
+            });
+        });
     }
 
     /**


### PR DESCRIPTION
Moved:
```php
if (!Config::get('winter.sso::prevent_native_auth', false)) return;
```

inside the closure in order to enable/disable native auth programmatically.